### PR TITLE
Added "from:" field to dpd-email example usage

### DIFF
--- a/docs/using-modules/official/email.md
+++ b/docs/using-modules/official/email.md
@@ -52,6 +52,7 @@ To send an email, call `dpd.email.post(options, callback)` (replacing `email` wi
 
     dpd.email.post({
       to: this.email,
+      from: "deployd-server@example.com", 
       subject: "MyApp registration",
       text: this.username + ",\n\n" +
             "Thank you for registering for MyApp!"


### PR DESCRIPTION
Depending on configuration of the dpd-email defaultFromAddress, the example usage would result in the following error:

`[Error: Can't set headers after they are sent.]`

By adding a 'from:' field to the example, this error can be avoided for that configuration condition.
